### PR TITLE
fix: match `rootProject.name` with modid

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,4 +4,5 @@
  * This project uses @Incubating APIs which are subject to change.
  */
 
-rootProject.name = "MarisaMod"
+rootProject.name = "MarisaContinued
+"


### PR DESCRIPTION
fix name mismatch caused by #51