### PR TITLE
fix: `MercuryHourglass` triggering when playing `PropBag`

### DIFF
--- a/src/main/kotlin/marisa/action/PropBagAction.kt
+++ b/src/main/kotlin/marisa/action/PropBagAction.kt
@@ -17,12 +17,8 @@ class PropBagAction : AbstractGameAction() {
     }
 
     private fun relicWithCounters() =
-        listOf(
-            LetterOpener(),
-            Shuriken(),
-            Kunai(),
-            OrnamentalFan()
-        ).onEach(AbstractRelic::atTurnStart)
+        listOf(LetterOpener(), Shuriken(), Kunai(), OrnamentalFan())
+            .onEach(AbstractRelic::atTurnStart)
 
     private fun relics() = listOf(
         MeatOnTheBone(), MummifiedHand(), BlueCandle(), AmplifyWand(),

--- a/src/main/kotlin/marisa/action/PropBagAction.kt
+++ b/src/main/kotlin/marisa/action/PropBagAction.kt
@@ -17,7 +17,12 @@ class PropBagAction : AbstractGameAction() {
     }
 
     private fun relicWithCounters() =
-        listOf(LetterOpener(), Shuriken(), Kunai(), OrnamentalFan()).onEach { it.counter = 0 }
+        listOf(
+            LetterOpener(),
+            Shuriken(),
+            Kunai(),
+            OrnamentalFan()
+        ).onEach(AbstractRelic::atTurnStart)
 
     private fun relics() = listOf(
         MeatOnTheBone(), MummifiedHand(), BlueCandle(), AmplifyWand(),

--- a/src/main/kotlin/marisa/action/PropBagAction.kt
+++ b/src/main/kotlin/marisa/action/PropBagAction.kt
@@ -16,19 +16,21 @@ class PropBagAction : AbstractGameAction() {
         duration = Settings.ACTION_DUR_FAST
     }
 
+    private fun relicWithCounters() =
+        listOf(LetterOpener(), Shuriken(), Kunai(), OrnamentalFan()).onEach { it.counter = 0 }
+
+    private fun relics() = listOf(
+        MeatOnTheBone(), MummifiedHand(), BlueCandle(), AmplifyWand(),
+        GremlinHorn(), MercuryHourglass(), Sundial(),
+    )
+
     override fun update() {
         val p = AbstractDungeon.player
         logger.info("PropBagAction : Checking for relics")
 
-        val relics = listOf(
-            MeatOnTheBone(), MummifiedHand(), BlueCandle(), AmplifyWand(),
-            GremlinHorn(), MercuryHourglass(), Sundial(),
-            // use atTurnStart to reset counter
-            LetterOpener(), Shuriken(), Kunai(), OrnamentalFan(),
-        )
-            .onEach(AbstractRelic::atTurnStart)
+        val relics = (relics() + relicWithCounters())
             .filterNot { p.hasRelic(it.relicId) }
-        // TODO: refactor with Arrow
+
 
         when (relics.size) {
             0 -> {


### PR DESCRIPTION
## Summary
- fixes #116 

### Why
previously relics of list were applied with `AbstractRelic::atTurnStart` to reset their counters, however `Mercurial Hourglass`, which does not use counter, also uses `atTurnStart` to deal 3 damage to all enemies.

## Changelog

#### fix: `MercuryHourglass` triggering when playing `PropBag` (fd2e465)

#### refactor: use `atTurnStart` to be consistent (8a6f93b)
