### PR TITLE
build: fix `move` task corrupting releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,12 +104,8 @@ tasks.jar {
 }
 
 
-tasks.register<Copy>("move") {
+tasks.register("changelog") {
     dependsOn(tasks.jar)
-    into("${gameDir}/${modID}")
-
-    from(jarFile) { into("content") }
-    from("docs/thumbnail/image.jpg")
     file("$gameDir/${modID}/config.json")
         .writeText(gson.toJson(Config(changeNote = changeBBCode)))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ tasks.register("modthespire") {
             |
             |${changeSts}
             """.trimMargin(),
-        version = File("docs/changelog/version.txt").readText()
+        version = File("docs/changelog/version.txt").readText().trim()
     )
 
     configFile.writeText(gson.toJson(config))

--- a/link.kts
+++ b/link.kts
@@ -15,6 +15,9 @@ fun Path.inode(): Long = Files.getAttribute(this, "unix:ino") as Long
 fun Path.forceCreateLinkTo(to: Path) {
     val target = to / fileName
 
+    println("${this.inode()} :: $this")
+    println("${target.inode()} :: $target")
+
     when {
         target.exists() && target.inode() == inode() -> return
         target.exists() -> target.deleteExisting()

--- a/releases.py
+++ b/releases.py
@@ -19,7 +19,7 @@ from typer import Argument, Typer
 BASE = Path("docs/changelog")
 
 CHANGELOG = BASE / "changelog.md"
-VERSION = (BASE / "version.txt").read_text()
+VERSION = (BASE / "version.txt").read_text().strip()
 
 CHANGELOG_TEXT = CHANGELOG.read_text()
 
@@ -52,6 +52,18 @@ def verify_jar_version():
     expected = VERSION
     actual = modjson["version"]
     assert expected == actual, f"{expected = } {actual = }"
+
+
+def verify_changelog_version():
+    """Verify changelog.md"""
+    CONFIG = Path(
+        "/home/scarf/Documents/SlayTheSpire/MarisaContinued/config.json"
+    ).read_text()
+
+    assert VERSION in CONFIG
+    assert VERSION in (BASE / "changelog.bbcode").read_text()
+    assert VERSION in (BASE / "changelog.sts.txt").read_text()
+    assert VERSION in CHANGELOG_TEXT
 
 
 def run_command(command: list[str], *, cwd=Path()):
@@ -103,6 +115,7 @@ app = Typer()
 @app.command(context_settings=dict(help_option_names=["-h", "--help"]))
 def main(command: Command = Argument(..., help=__doc__)):
     verify_jar_version()
+    verify_changelog_version()
 
     fx = Command.to_func(command)
     # pylint: disable-next=not-an-iterable


### PR DESCRIPTION
## Summary
- fixes #119 

## Changelog

#### build(github): strip version newline (f42e719)
and extra check on version number

#### build: show hard link inode (b314e55)

#### build: replace `move` task to `changelog` (9f84383)
because `link.kts` hardlink files, running `move` corrupts them and prevent submitting to steam workshop
