### PR TITLE
fix(L10n): `binarystar` wrongly marked as `exhaust`

### DIFF
--- a/src/main/resources/localization/KOR/cards.json
+++ b/src/main/resources/localization/KOR/cards.json
@@ -322,8 +322,8 @@
   },
   "BinaryStars": {
     "NAME": "쌍성",
-    "DESCRIPTION": "*흑섬광성 또는 *백색왜성 카드를 선택해 얻습니다. NL 증폭 [E] : 두 카드를 모두 얻습니다. NL 소멸.",
-    "UPGRADE_DESCRIPTION": "*흑섬광성+ 또는 *백색왜성+ 카드를 선택해 얻습니다. NL 증폭 [E] : 두 카드를 모두 얻습니다. NL 소멸."
+    "DESCRIPTION": "*흑섬광성 또는 *백색왜성 카드를 선택해 얻습니다. NL 증폭 [E] : 두 카드를 모두 얻습니다.",
+    "UPGRADE_DESCRIPTION": "*흑섬광성+ 또는 *백색왜성+ 카드를 선택해 얻습니다. NL 증폭 [E] : 두 카드를 모두 얻습니다."
   },
   "CollectingQuirk": {
     "NAME": "골동품 수집",


### PR DESCRIPTION
## Summary
- fixes #121

<table>
<tr>
	<th>Binary Star
	<th>Binary Star+
<tr>
	<td>
		<img src="https://user-images.githubusercontent.com/54838975/213109481-2c4890d5-43b4-4a5d-ae8c-b1f35f4c87c0.png"/>
	<td>
		<img src="https://user-images.githubusercontent.com/54838975/213109565-94f0cb4d-8fc9-4a27-83d1-bea7df06d9ac.png"/>
</table>

## Changelog

#### fix(L10n): `binarystar` wrongly marked as `exhaust` (7ac1187)
