### PR TITLE
fix: crashing when using `Blaze Away` without target

### DIFF
--- a/releases.py
+++ b/releases.py
@@ -29,6 +29,7 @@ BODY = "\n".join(CHANGELOG_TEXT.splitlines()[2:])
 
 JAR = zipfile.Path("build/libs/MarisaContinued.jar")
 MODINFO = JAR / "ModTheSpire.json"
+STS = Path().home() / ".steam/steam/steamapps/common/" / "SlayTheSpire"
 
 
 @dataclass
@@ -67,9 +68,7 @@ def verify_jar_version():
 
 def verify_changelog_version():
     """Verify changelog.md"""
-    CONFIG = Path(
-        "/home/scarf/.steam/steam/steamapps/common/SlayTheSpire/MarisaContinued/config.json"
-    ).read_text()
+    CONFIG = (STS / "MarisaContinued" / "config.json").read_text()
 
     assert VERSION in CONFIG
     assert VERSION in (BASE / "changelog.bbcode").read_text()
@@ -98,7 +97,6 @@ def github(ctx: Context):
 
 
 def steam(_: Context):
-    STS = Path("/home/scarf/Documents/SlayTheSpire/")
     COMMAND = "java -jar mod-uploader.jar upload -w MarisaContinued/".split(
         " "
     )

--- a/releases.py
+++ b/releases.py
@@ -138,7 +138,10 @@ def main(
     print(f"Will run the following commands: {names}")
     wait()
     with ProcessPoolExecutor() as executor:
-        executor.map(runner, fx)
+        result = executor.map(runner, fx)
+
+        for r in result:
+            print(r)
 
 
 if __name__ == "__main__":

--- a/src/main/kotlin/marisa/Action.kt
+++ b/src/main/kotlin/marisa/Action.kt
@@ -23,3 +23,8 @@ fun ApplyPowerToPlayerAction(powerClass: KClass<out AbstractPower>) =
 
 fun AbstractPower.RemoveSelfAction(): RemoveSpecificPowerAction =
     RemoveSpecificPowerAction(owner, owner, this)
+
+fun AbstractGameAction.updateContext(block: () -> Unit) {
+    block()
+    isDone = true
+}

--- a/src/main/kotlin/marisa/action/BlazeAwayAction.kt
+++ b/src/main/kotlin/marisa/action/BlazeAwayAction.kt
@@ -8,6 +8,7 @@ import com.megacrit.cardcrawl.cards.CardQueueItem
 import com.megacrit.cardcrawl.core.Settings
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import marisa.MarisaContinued
+import marisa.updateContext
 
 class BlazeAwayAction(val card: AbstractCard) : AbstractGameAction() {
 
@@ -17,8 +18,8 @@ class BlazeAwayAction(val card: AbstractCard) : AbstractGameAction() {
         MarisaContinued.logger.info("BlazeAwayAction : Initialize complete ; card : ${card.name}")
     }
 
-    override fun update() {
-        val target = AbstractDungeon.getMonsters().getRandomMonster(true)
+    override fun update() = updateContext {
+        val target = AbstractDungeon.getMonsters().getRandomMonster(true) ?: return@updateContext
 
         AbstractDungeon.player.limbo.group.add(card)
         card.apply {
@@ -42,6 +43,5 @@ class BlazeAwayAction(val card: AbstractCard) : AbstractGameAction() {
             cardQueue.add(CardQueueItem(card, target))
             addToTop(WaitAction(duration))
         }
-        isDone = true
     }
 }

--- a/src/main/kotlin/marisa/cards/BlazeAway.kt
+++ b/src/main/kotlin/marisa/cards/BlazeAway.kt
@@ -41,18 +41,18 @@ class BlazeAway : CustomCard(
     }
 
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
-        lastAttack()?.let { last ->
-            MarisaContinued.logger.info("""BlazeAway : last attack :${last.cardID}""")
-            val card = last.makeStatEquivalentCopy()
-                .also {
-                    MarisaContinued.logger.info(
-                        """BlazeAway: card :$cardID; 
+        val last = lastAttack() ?: return
+
+        MarisaContinued.logger.info("""BlazeAway : last attack :${last.cardID}""")
+        val card = last.makeStatEquivalentCopy()
+            .also {
+                MarisaContinued.logger.info(
+                    """BlazeAway: card :$cardID; 
                             |baseD :$baseDamage; Damage: $damage; baseB :$baseBlock ; B : $block ; 
                             |baseM :$baseMagicNumber ; M : $magicNumber ; C : $cost ; CFT : $costForTurn""".trimMargin()
-                    )
-                }
-            repeat(magicNumber) { addToBot(BlazeAwayAction(card)) }
-        }
+                )
+            }
+        repeat(magicNumber) { addToBot(BlazeAwayAction(card)) }
     }
 
     override fun makeCopy(): AbstractCard = BlazeAway()

--- a/src/main/kotlin/marisa/cards/BlazeAway.kt
+++ b/src/main/kotlin/marisa/cards/BlazeAway.kt
@@ -61,10 +61,6 @@ class BlazeAway : CustomCard(
         if (!upgraded) {
             upgradeMagicNumber(UPG_NUM)
             upgradeName()
-            //upgradeBaseCost(0);
-            //this.rawDescription = DESCRIPTION_UPG;
-            //initializeDescription();
-            //this.exhaust = false;
         }
     }
 


### PR DESCRIPTION
## Summary
- fixes #133 

## Changelog

#### refactor: un-nest lastAttack (7c5e49f)

#### refactor: remove comment (f3a48a6)

#### refactor: RAII for `isDone` (d421a4c)

#### fix: NPE when target is `null` (be327d2)
