### PR TITLE
feat!: remove `Guiding Star` from card pool

### DIFF
--- a/pr.py
+++ b/pr.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
+import json
 import re
 import sys
 from subprocess import run
-from typing import Final, NewType
+from typing import Final, NewType, TypedDict
+
+from flupy import flu
 
 
 def get_commit_titles():
@@ -25,16 +28,58 @@ def get_title() -> str:
         case _:
             if len(titles := get_commit_titles()) == 1:
                 return titles[0]
-            if (
-                result := input(
-                    "Enter commit title (empty to choose from existing commits): "
-                )
-            ) != "":
+            result = input(
+                "Enter commit title (empty to choose from existing commits): "
+            )
+            if (result) != "":
                 return result
 
             for i, title in enumerate(titles):
                 print(f"[{i}] {title}")
             return titles[int(input("Enter commit number: "))]
+
+
+class Issue(TypedDict):
+    number: int
+    title: str
+
+
+def open_issues() -> list[Issue]:
+    args = ["gh", "issue", "list", "--state", "open", "--json", "number,title"]
+    text = run(args, capture_output=True, check=True).stdout.decode("utf-8")
+    return json.loads(text)
+
+
+def choose_issues(issues: list[Issue]) -> int | None:
+    issue_nums = flu(issues).map(lambda x: x["number"]).collect()
+    for item in issues:
+        number, title = item["number"], item["title"]
+        print(f"[{number}] {title}")
+
+    def invalid():
+        print(
+            "Invalid issue number, choose between "
+            f"{', '.join(map(str, issue_nums))}"
+        )
+
+    while True:
+        try:
+            text = input("Enter issue number (empty to skip): ")
+            if text == "":
+                return None
+            if (result := int(text)) in issue_nums:
+                return result
+            raise ValueError
+        except ValueError:
+            invalid()
+        except KeyboardInterrupt:
+            print("Aborted")
+            sys.exit(0)
+
+
+def get_issue_number() -> int | None:
+    issues = open_issues()
+    return choose_issues(issues)
 
 
 commit_regex = re.compile(r"(?P<type>.+): (?P<subject>.*)")
@@ -60,10 +105,11 @@ commits: Final = run(
     capture_output=True,
     check=True,
 ).stdout.decode("utf-8")
+issue: Final = get_issue_number()
 
 BODY = f"""\
 ## Summary
-- fixes #
+- fixes #{issue or ""}
 
 ## Changelog
 

--- a/src/main/kotlin/marisa/MarisaContinued.kt
+++ b/src/main/kotlin/marisa/MarisaContinued.kt
@@ -300,9 +300,6 @@ class MarisaContinued :
 
         @JvmStatic
         val randomMarisaCard: AbstractCard
-            get() = when (AbstractDungeon.miscRng.random(0, 100)) {
-                15 -> GuidingStar()
-                else -> AbstractDungeon.returnTrulyRandomCardInCombat().makeCopy()
-            }
+            get() = AbstractDungeon.returnTrulyRandomCardInCombat().makeCopy()
     }
 }


### PR DESCRIPTION
## Summary
- fixes #132

## Changelog

#### feat!: remove `Guiding Star` from card pool (b97001a)
It was an obsolete card originally used with `Polaris Unique`. To reduce confusion (and keep L10n up to date), it's excluded from random card generation pool.

#### build: also close issue (a1df7e5)
