### PR TITLE
fix: blazeaway not making last attack free

### DIFF
--- a/src/main/kotlin/marisa/action/BlazeAwayAction.kt
+++ b/src/main/kotlin/marisa/action/BlazeAwayAction.kt
@@ -27,7 +27,7 @@ class BlazeAwayAction(val card: AbstractCard) : AbstractGameAction() {
             current_y = Settings.HEIGHT / 2.0f
             target_x = Settings.WIDTH / 2.0f - 300.0f * Settings.scale
             target_y = Settings.HEIGHT / 2.0f
-            freeToPlayOnce = true
+            costForTurn = 0
             purgeOnUse = true
             targetAngle = 0.0f
             drawScale = 0.12f

--- a/src/main/kotlin/marisa/cards/BlazeAway.kt
+++ b/src/main/kotlin/marisa/cards/BlazeAway.kt
@@ -43,16 +43,17 @@ class BlazeAway : CustomCard(
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
         val last = lastAttack() ?: return
 
-        MarisaContinued.logger.info("""BlazeAway : last attack :${last.cardID}""")
-        val card = last.makeStatEquivalentCopy()
-            .also {
-                MarisaContinued.logger.info(
-                    """BlazeAway: card :$cardID; 
-                            |baseD :$baseDamage; Damage: $damage; baseB :$baseBlock ; B : $block ; 
-                            |baseM :$baseMagicNumber ; M : $magicNumber ; C : $cost ; CFT : $costForTurn""".trimMargin()
-                )
-            }
-        repeat(magicNumber) { addToBot(BlazeAwayAction(card)) }
+        MarisaContinued.logger.info("""BlazeAway: last attack :${last.cardID}""")
+        val lastCard = last.makeStatEquivalentCopy()
+
+        with(lastCard) {
+            MarisaContinued.logger.info(
+                """BlazeAway: card :$cardID; 
+                        |baseD: $baseDamage; Damage: $damage; baseB :$baseBlock ; B: $block ; 
+                        |baseM: $baseMagicNumber ; M : $magicNumber ; C : $cost ; CFT: $costForTurn""".trimMargin()
+            )
+        }
+        repeat(magicNumber) { addToBot(BlazeAwayAction(lastCard)) }
     }
 
     override fun makeCopy(): AbstractCard = BlazeAway()

--- a/src/main/kotlin/marisa/cards/BlazeAway.kt
+++ b/src/main/kotlin/marisa/cards/BlazeAway.kt
@@ -22,7 +22,7 @@ class BlazeAway : CustomCard(
     CardTarget.SELF
 ) {
     init {
-        magicNumber = NUM
+        magicNumber = USE_TIMES
         baseMagicNumber = magicNumber
     }
 
@@ -59,7 +59,7 @@ class BlazeAway : CustomCard(
 
     override fun upgrade() {
         if (!upgraded) {
-            upgradeMagicNumber(UPG_NUM)
+            upgradeMagicNumber(UPGRADE_USE_TIMES)
             upgradeName()
         }
     }
@@ -80,7 +80,7 @@ class BlazeAway : CustomCard(
             Description(it[0], it[1], it[2])
         }
         private const val COST = 1
-        private const val NUM = 1
-        private const val UPG_NUM = 1
+        private const val USE_TIMES = 1
+        private const val UPGRADE_USE_TIMES = 1
     }
 }


### PR DESCRIPTION
## Summary
- fixes #152

## Changelog

#### refactor: make consts more verbose (58ef596)

#### fix: logging blazeaway instead of last attack (c52f6f1)
also passes context object in `it`, not `this`.
changed to use with, which does pass context object in `this`.
see: https://kotlinlang.org/docs/scope-functions.html

#### fix: blazeaway not making last attack free (eaf5118)
freeToPlayOnce seems to only work on X cost cards.
used `costForTurn` modifier to explicitly make it zero cost.

see: https://github.com/daviscook477/BaseMod/blob/1cb2774cc517e10fd2777e5da128d02913e930a0/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/ModifyXCostPatch.java#L31