### PR TITLE
feat: glow when card can be amplified

### DIFF
--- a/src/main/kotlin/marisa/Action.kt
+++ b/src/main/kotlin/marisa/Action.kt
@@ -5,18 +5,28 @@ package marisa
 import com.megacrit.cardcrawl.actions.AbstractGameAction
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction
+import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
+import com.megacrit.cardcrawl.monsters.AbstractMonster
 import com.megacrit.cardcrawl.powers.AbstractPower
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 
-val p get() = AbstractDungeon.player
+val p: AbstractPlayer get() = AbstractDungeon.player
+val monsters: ArrayList<AbstractMonster> get() = AbstractDungeon.getCurrRoom().monsters.monsters
 
 fun addToBot(vararg actions: AbstractGameAction) =
     actions.forEach { AbstractDungeon.actionManager.addToBottom(it) }
 
+fun addToBot(actions: List<AbstractGameAction>) =
+    actions.forEach { AbstractDungeon.actionManager.addToBottom(it) }
+
 fun addToTop(vararg actions: AbstractGameAction) =
     actions.forEach { AbstractDungeon.actionManager.addToTop(it) }
+
+fun addToTop(actions: List<AbstractGameAction>) =
+    actions.forEach { AbstractDungeon.actionManager.addToTop(it) }
+
 
 fun ApplyPowerToPlayerAction(powerClass: KClass<out AbstractPower>) =
     powerClass.primaryConstructor?.call(p).let { power -> ApplyPowerAction(p, p, power) }

--- a/src/main/kotlin/marisa/MarisaContinued.kt
+++ b/src/main/kotlin/marisa/MarisaContinued.kt
@@ -8,7 +8,6 @@ import com.badlogic.gdx.graphics.Color
 import com.evacipated.cardcrawl.modthespire.lib.SpireConfig
 import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer
 import com.google.gson.Gson
-import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
 import com.megacrit.cardcrawl.actions.common.GainEnergyAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.core.Settings
@@ -20,7 +19,6 @@ import com.megacrit.cardcrawl.helpers.FontHelper
 import com.megacrit.cardcrawl.helpers.ImageMaster
 import com.megacrit.cardcrawl.localization.*
 import com.megacrit.cardcrawl.potions.AbstractPotion
-import com.megacrit.cardcrawl.ui.panels.EnergyPanel
 import marisa.action.SparkCostAction
 import marisa.cards.*
 import marisa.cards.derivations.*
@@ -246,57 +244,6 @@ class MarisaContinued :
 
         @JvmField
         var isDeadBranchEnabled: Boolean = false
-
-        /** TODO: it does lots of stuff I cannot understand, split it into multiple parts */
-        fun isAmplified(card: AbstractCard, cost: Int): Boolean {
-            logger.info(
-                """ThMod.Amplified : card to check : ${card.cardID}; costForTurn : ${card.costForTurn}"""
-            )
-            val p = AbstractDungeon.player
-
-            fun isFree() =
-                p.hasPower(MillisecondPulsarsPower.POWER_ID) || p.hasPower(PulseMagicPower.POWER_ID)
-                        || card.freeToPlayOnce || card.purgeOnUse
-
-            fun canPay() = EnergyPanel.totalCount >= card.costForTurn + cost
-
-            if (p.hasPower(OneTimeOffPlusPower.POWER_ID) || p.hasPower(OneTimeOffPower.POWER_ID)) {
-                logger.info("ThMod.Amplified :OneTimeOff detected,returning false.")
-                return false
-            }
-
-            val res = when {
-                isFree() -> {
-                    logger.info(
-                        """ThMod.Amplified :Free Amplify tag detected,returning true : Milli :${
-                            p.hasPower(MillisecondPulsarsPower.POWER_ID)
-                        } ; 
-                        |Pulse :${p.hasPower(PulseMagicPower.POWER_ID)} ; 
-                        |Free2Play :${card.freeToPlayOnce} ; 
-                        |purge on use :${card.purgeOnUse}""".trimMargin()
-                    )
-                    true
-                }
-
-                canPay() -> {
-                    logger.info("ThMod.Amplified : Sufficient energy, adding and returning true;")
-                    card.costForTurn += cost
-                    true
-                }
-
-                else -> false
-            }
-
-            if (res) {
-                AbstractDungeon.actionManager.addToTop(ApplyPowerAction(p, p, GrandCrossPower(p)))
-                p.getPower(EventHorizonPower.POWER_ID)?.onSpecificTrigger()
-                p.getRelic(AmplifyWand.ID)?.onTrigger()
-            }
-            logger.info(
-                """ThMod.Amplified : card : ${card.cardID} ; Amplify : $res ; costForTurn : ${card.costForTurn}"""
-            )
-            return res
-        }
 
         @JvmStatic
         val randomMarisaCard: AbstractCard

--- a/src/main/kotlin/marisa/abstracts/AmplifiableCard.kt
+++ b/src/main/kotlin/marisa/abstracts/AmplifiableCard.kt
@@ -1,0 +1,87 @@
+package marisa.abstracts
+
+import basemod.abstracts.CustomCard
+import com.megacrit.cardcrawl.ui.panels.EnergyPanel
+import marisa.ApplyPowerToPlayerAction
+import marisa.MarisaContinued
+import marisa.addToTop
+import marisa.p
+import marisa.powers.Marisa.*
+import marisa.relics.AmplifyWand
+
+fun applyAmplify() {
+    addToTop(ApplyPowerToPlayerAction(GrandCrossPower::class))
+    p.getPower(EventHorizonPower.POWER_ID)?.onSpecificTrigger()
+    p.getRelic(AmplifyWand.ID)?.onTrigger()
+}
+
+fun isAmplifyDisabled() = when {
+    p.hasPower(OneTimeOffPower.POWER_ID) -> true
+    p.hasPower(OneTimeOffPlusPower.POWER_ID) -> true
+    else -> false
+}
+
+abstract class AmplifiableCard(
+    id: String,
+    name: String,
+    img: String,
+    cost: Int,
+    rawDescription: String,
+    type: CardType,
+    color: CardColor,
+    rarity: CardRarity,
+    target: CardTarget,
+) : CustomCard(
+    id,
+    name,
+    img,
+    cost,
+    rawDescription,
+    type,
+    color,
+    rarity,
+    target
+) {
+    var amplifyCost = 1
+
+    fun isFreeAmplify(): Boolean = when {
+        p.hasPower(MillisecondPulsarsPower.POWER_ID) -> true
+        p.hasPower(PulseMagicPower.POWER_ID) -> true
+        freeToPlayOnce -> true
+        else -> false
+//        purgeOnUse -> true
+    }
+
+    override fun triggerOnGlowCheck() {
+        val color = if (canAmplify()) GOLD_BORDER_GLOW_COLOR else BLUE_BORDER_GLOW_COLOR
+        glowColor = color.cpy()
+    }
+
+    fun canPayAmplify() = EnergyPanel.totalCount >= costForTurn + amplifyCost
+
+    fun canAmplify(): Boolean = when {
+        isAmplifyDisabled() -> false
+        isFreeAmplify() -> true
+        canPayAmplify() -> true
+        else -> false
+    }
+
+    fun additionalCostToPay() = when {
+        isFreeAmplify() -> 0
+        canPayAmplify() -> amplifyCost
+        else -> 0
+    }
+
+    fun tryAmplify(): Boolean {
+        MarisaContinued.logger.info("""Card to be Amplified: ${cardID} with costForTurn : ${costForTurn}""")
+
+        costForTurn += additionalCostToPay()
+
+        val res = canAmplify()
+        if (res) {
+            applyAmplify()
+        }
+        MarisaContinued.logger.info("""Amplified : card : $cardID; Amplify : $res ; costForTurn : $costForTurn""")
+        return res
+    }
+}

--- a/src/main/kotlin/marisa/abstracts/AmplifiedAttack.kt
+++ b/src/main/kotlin/marisa/abstracts/AmplifiedAttack.kt
@@ -1,21 +1,21 @@
 package marisa.abstracts
 
-import basemod.abstracts.CustomCard
 import com.badlogic.gdx.math.MathUtils
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import com.megacrit.cardcrawl.monsters.AbstractMonster
 
+
 abstract class AmplifiedAttack(
-    id: String?,
-    name: String?,
-    img: String?,
+    id: String,
+    name: String,
+    img: String,
     cost: Int,
-    rawDescription: String?,
-    type: CardType?,
-    color: CardColor?,
-    rarity: CardRarity?,
-    target: CardTarget?
-) : CustomCard(
+    rawDescription: String,
+    type: CardType,
+    color: CardColor,
+    rarity: CardRarity,
+    target: CardTarget,
+) : AmplifiableCard(
     id,
     name,
     img,
@@ -30,6 +30,7 @@ abstract class AmplifiedAttack(
     protected var ampNumber = 0
     protected lateinit var multiAmpDamage: IntArray
     protected var isException = false
+
     override fun applyPowers() {
         if (!isException) {
             damage = baseDamage

--- a/src/main/kotlin/marisa/action/WasteBombAction.kt
+++ b/src/main/kotlin/marisa/action/WasteBombAction.kt
@@ -10,7 +10,6 @@ import com.megacrit.cardcrawl.core.AbstractCreature
 import com.megacrit.cardcrawl.core.Settings
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import com.megacrit.cardcrawl.vfx.combat.FlashAtkImgEffect
-import marisa.MarisaContinued
 import marisa.powers.Marisa.TempStrengthLoss
 
 class WasteBombAction(private val target: AbstractCreature?, dmg: Int, numTimes: Int, stacks: Int) :
@@ -36,11 +35,6 @@ class WasteBombAction(private val target: AbstractCreature?, dmg: Int, numTimes:
         }
         if (AbstractDungeon.getCurrRoom().monsters.areMonstersBasicallyDead()) {
             AbstractDungeon.actionManager.clearPostCombatActions()
-            isDone = true
-            return
-        }
-        if (this.target == null) {
-            MarisaContinued.logger.info("WasteBombAction : error : target == null !")
             isDone = true
             return
         }

--- a/src/main/kotlin/marisa/cards/Acceleration.kt
+++ b/src/main/kotlin/marisa/cards/Acceleration.kt
@@ -1,14 +1,14 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.DrawCardAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
+import marisa.abstracts.AmplifiableCard
 import marisa.patches.AbstractCardEnum
 
-class Acceleration : CustomCard(
+class Acceleration : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -30,7 +30,7 @@ class Acceleration : CustomCard(
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
         addToBot(DrawCardAction(block))
 
-        if (isAmplified()) {
+        if (tryAmplify()) {
             addToBot(DrawCardAction(magicNumber))
         }
     }
@@ -47,8 +47,8 @@ class Acceleration : CustomCard(
     companion object {
         const val ID = "Acceleration"
         private val cardStrings = CardCrawlGame.languagePack.getCardStrings(ID)
-        val NAME: String? = cardStrings.NAME
-        val DESCRIPTION: String? = cardStrings.DESCRIPTION
+        val NAME: String = cardStrings.NAME
+        val DESCRIPTION: String = cardStrings.DESCRIPTION
         const val IMG_PATH = "img/cards/GuidingStar.png"
         private const val COST = 0
         private const val DRAW = 2

--- a/src/main/kotlin/marisa/cards/AlicesGift.kt
+++ b/src/main/kotlin/marisa/cards/AlicesGift.kt
@@ -1,15 +1,15 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.AbstractGameAction.AttackEffect
 import com.megacrit.cardcrawl.actions.common.DamageAction
 import com.megacrit.cardcrawl.cards.DamageInfo
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
+import marisa.abstracts.AmplifiableCard
 import marisa.patches.AbstractCardEnum
 
-class AlicesGift : CustomCard(
+class AlicesGift : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -24,6 +24,7 @@ class AlicesGift : CustomCard(
         baseDamage = ATK
         damage = baseDamage
         exhaust = true
+        amplifyCost = AMP
     }
 
     override fun upgrade() {
@@ -39,15 +40,11 @@ class AlicesGift : CustomCard(
     }
 
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
-        if (isAmplified(AMP)) {
+        if (tryAmplify()) {
             damage *= 3
         }
         addToBot(
-            DamageAction(
-                m,
-                DamageInfo(p, damage, damageTypeForTurn),
-                AttackEffect.FIRE
-            )
+            DamageAction(m, DamageInfo(p, damage, damageTypeForTurn), AttackEffect.FIRE)
         )
     }
 

--- a/src/main/kotlin/marisa/cards/AsteroidBelt.kt
+++ b/src/main/kotlin/marisa/cards/AsteroidBelt.kt
@@ -1,6 +1,5 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
 import com.megacrit.cardcrawl.actions.common.GainBlockAction
 import com.megacrit.cardcrawl.cards.AbstractCard
@@ -8,9 +7,10 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
 import com.megacrit.cardcrawl.powers.NextTurnBlockPower
+import marisa.abstracts.AmplifiableCard
 import marisa.patches.AbstractCardEnum
 
-class AsteroidBelt : CustomCard(
+class AsteroidBelt : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -23,21 +23,15 @@ class AsteroidBelt : CustomCard(
 ) {
     init {
         baseBlock = BLOCK_AMT
+        amplifyCost = AMP
     }
 
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
         addToBot(
             GainBlockAction(p, p, block)
         )
-        if (isAmplified(AMP)) {
-            addToBot(
-                ApplyPowerAction(
-                    p,
-                    p,
-                    NextTurnBlockPower(p, block),
-                    block
-                )
-            )
+        if (tryAmplify()) {
+            addToBot(ApplyPowerAction(p, p, NextTurnBlockPower(p, block), block))
         }
     }
 

--- a/src/main/kotlin/marisa/cards/BinaryStars.kt
+++ b/src/main/kotlin/marisa/cards/BinaryStars.kt
@@ -1,18 +1,17 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
-import marisa.MarisaContinued
+import marisa.abstracts.AmplifiableCard
 import marisa.action.BinaryStarsAction
 import marisa.cards.derivations.BlackFlareStar
 import marisa.cards.derivations.WhiteDwarf
 import marisa.patches.AbstractCardEnum
 
-class BinaryStars : CustomCard(
+class BinaryStars : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -24,12 +23,13 @@ class BinaryStars : CustomCard(
     CardTarget.SELF
 ) {
     init {
+        amplifyCost = AMP
         multiplePreviews(stars())
     }
 
     private fun stars() = listOf(WhiteDwarf(), BlackFlareStar()).map { followUpgrade(it) }
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
-        if (isAmplified(AMP)) {
+        if (tryAmplify()) {
             stars().forEach { addToBot(MakeTempCardInHandAction(it, 1)) }
         } else {
             addToBot(BinaryStarsAction(upgraded))

--- a/src/main/kotlin/marisa/cards/BlazingStar.kt
+++ b/src/main/kotlin/marisa/cards/BlazingStar.kt
@@ -32,6 +32,7 @@ class BlazingStar : AmplifiedAttack(
         magicNumber = baseMagicNumber
         isException = true
         cardsToPreview = Burn()
+        amplifyCost = AMP
     }
 
     private fun burns() = AbstractDungeon.player.hand.group.filterIsInstance<Burn>().size
@@ -51,15 +52,11 @@ class BlazingStar : AmplifiedAttack(
     }
 
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
-        if (isAmplified(AMP)) {
+        if (tryAmplify()) {
             block *= 2
         }
         addToBot(
-            DamageAction(
-                m,
-                DamageInfo(p, block, damageTypeForTurn),
-                AttackEffect.FIRE
-            )
+            DamageAction(m, DamageInfo(p, block, damageTypeForTurn), AttackEffect.FIRE)
         )
     }
 

--- a/src/main/kotlin/marisa/cards/DeepEcologicalBomb.kt
+++ b/src/main/kotlin/marisa/cards/DeepEcologicalBomb.kt
@@ -1,15 +1,15 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import com.megacrit.cardcrawl.monsters.AbstractMonster
+import marisa.abstracts.AmplifiableCard
 import marisa.action.WasteBombAction
 import marisa.patches.AbstractCardEnum
 
-class DeepEcologicalBomb : CustomCard(
+class DeepEcologicalBomb : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -24,14 +24,12 @@ class DeepEcologicalBomb : CustomCard(
         baseDamage = ATK_DMG
         baseMagicNumber = STC
         magicNumber = baseMagicNumber
+        amplifyCost = AMP
     }
 
     override fun calculateCardDamage(unused: AbstractMonster?) {}
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
-        var num = 1
-        if (isAmplified(AMP)) {
-            num++
-        }
+        val num = if (tryAmplify()) 2 else 1
         addToBot(
             WasteBombAction(
                 AbstractDungeon.getMonsters().getRandomMonster(true),

--- a/src/main/kotlin/marisa/cards/EarthLightRay.kt
+++ b/src/main/kotlin/marisa/cards/EarthLightRay.kt
@@ -1,16 +1,16 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.HealAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
+import marisa.abstracts.AmplifiableCard
 import marisa.action.DiscToHandRandAction
 import marisa.action.DiscardPileToHandAction
 import marisa.patches.AbstractCardEnum
 
-class EarthLightRay : CustomCard(
+class EarthLightRay : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -21,7 +21,6 @@ class EarthLightRay : CustomCard(
     CardRarity.UNCOMMON,
     CardTarget.SELF
 ) {
-    private val AMP = 1
 
     init {
         magicNumber = HEAL_AMT
@@ -32,7 +31,7 @@ class EarthLightRay : CustomCard(
 
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
         if (!p.discardPile.isEmpty) {
-            if (isAmplified(AMP)) {
+            if (tryAmplify()) {
                 if (upgraded && !p.discardPile.isEmpty) {
                     addToBot(
                         DiscardPileToHandAction(1)
@@ -44,9 +43,7 @@ class EarthLightRay : CustomCard(
                 }
             }
         }
-        addToBot(
-            HealAction(p, p, magicNumber)
-        )
+        addToBot(HealAction(p, p, magicNumber))
     }
 
     override fun makeCopy(): AbstractCard = EarthLightRay()

--- a/src/main/kotlin/marisa/cards/FairyDestructionRay.kt
+++ b/src/main/kotlin/marisa/cards/FairyDestructionRay.kt
@@ -1,6 +1,5 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.AbstractGameAction.AttackEffect
 import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction
 import com.megacrit.cardcrawl.cards.AbstractCard
@@ -8,10 +7,11 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import com.megacrit.cardcrawl.monsters.AbstractMonster
+import marisa.abstracts.AmplifiableCard
 import marisa.action.FairyDestrucCullingAction
 import marisa.patches.AbstractCardEnum
 
-class FairyDestructionRay : CustomCard(
+class FairyDestructionRay : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -28,22 +28,18 @@ class FairyDestructionRay : CustomCard(
         baseDamage = damage
         baseMagicNumber = DIASPORA
         magicNumber = baseMagicNumber
+        amplifyCost = AMP
     }
 
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
         addToBot(
             DamageAllEnemiesAction(
-                p,
-                multiDamage,
-                damageTypeForTurn,
-                AttackEffect.SLASH_DIAGONAL
+                p, multiDamage, damageTypeForTurn, AttackEffect.SLASH_DIAGONAL
             )
         )
         if (!AbstractDungeon.getCurrRoom().monsters.areMonstersBasicallyDead()) {
-            if (isAmplified(AMP)) {
-                addToBot(
-                    FairyDestrucCullingAction(magicNumber)
-                )
+            if (tryAmplify()) {
+                addToBot(FairyDestrucCullingAction(magicNumber))
             }
         }
     }

--- a/src/main/kotlin/marisa/cards/LuminesStrike.kt
+++ b/src/main/kotlin/marisa/cards/LuminesStrike.kt
@@ -10,6 +10,7 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import com.megacrit.cardcrawl.monsters.AbstractMonster
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel
 import marisa.abstracts.AmplifiedAttack
+import marisa.p
 import marisa.patches.AbstractCardEnum
 
 class LuminesStrike : AmplifiedAttack(
@@ -32,21 +33,9 @@ class LuminesStrike : AmplifiedAttack(
     }
 
     override fun applyPowers() {
-        val player = AbstractDungeon.player
-        damage = player.hand.size() * baseMagicNumber + baseDamage
+        damage = p.hand.size() * baseMagicNumber + baseDamage
         block = EnergyPanel.totalCount * baseBlock + baseDamage
-        /*
-    ThMod.logger.info(
-        "LuminesStrike : applyPowers : player hand size :" +
-            player.hand.size() +
-            " ; damage : " +
-            damage +
-            " ; current energy : " +
-            EnergyPanel.totalCount +
-            " ; amplified : " +
-            block
-    );
-    */super.applyPowers()
+        super.applyPowers()
     }
 
     override fun calculateDamageDisplay(mo: AbstractMonster?) {
@@ -55,40 +44,17 @@ class LuminesStrike : AmplifiedAttack(
 
     override fun calculateCardDamage(mo: AbstractMonster?) {
         val player = AbstractDungeon.player
-        /*
-    ThMod.logger.info(
-        "LuminesStrike : calculateCardDamage : player hand size :" +
-            player.hand.size() +
-            " ; damage : " +
-            damage +
-            " ; current energy : " +
-            EnergyPanel.totalCount +
-            " ; amplified : " +
-            block
-    );
-    */damage = player.hand.size() * baseMagicNumber + baseDamage
+        damage = player.hand.size() * baseMagicNumber + baseDamage
         block = EnergyPanel.totalCount * baseBlock + baseDamage
         super.calculateCardDamage(mo)
     }
 
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
-        if (isAmplified(AMP)) {
-            addToBot(
-                DamageAction(
-                    m,
-                    DamageInfo(p, block, damageTypeForTurn),
-                    AttackEffect.SLASH_DIAGONAL
-                )
-            )
-        } else {
-            addToBot(
-                DamageAction(
-                    m,
-                    DamageInfo(p, damage, damageTypeForTurn),
-                    AttackEffect.SLASH_DIAGONAL
-                )
-            )
-        }
+        val damageNumber = if (tryAmplify()) block else damage
+        val action = DamageAction(
+            m, DamageInfo(p, damageNumber, damageTypeForTurn), AttackEffect.SLASH_DIAGONAL
+        )
+        addToBot(action)
     }
 
     override fun makeCopy(): AbstractCard = LuminesStrike()
@@ -115,6 +81,5 @@ class LuminesStrike : AmplifiedAttack(
         private const val D1 = 3
         private const val A0 = 4
         private const val A1 = 5
-        private const val AMP = 1
     }
 }

--- a/src/main/kotlin/marisa/cards/MasterSpark.kt
+++ b/src/main/kotlin/marisa/cards/MasterSpark.kt
@@ -32,28 +32,13 @@ class MasterSpark : AmplifiedAttack(
     }
 
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
-        addToBot(
-            VFXAction(
-                MindblastEffect(p.dialogX, p.dialogY, false)
-            )
+        val damageNumber = if (tryAmplify()) block else damage
+        val blast = VFXAction(MindblastEffect(p.dialogX, p.dialogY, false))
+        val action = DamageAction(
+            m, DamageInfo(p, damageNumber, damageTypeForTurn), AttackEffect.SLASH_DIAGONAL
         )
-        if (isAmplified(AMP)) {
-            addToBot(
-                DamageAction(
-                    m,
-                    DamageInfo(p, block, damageTypeForTurn),
-                    AttackEffect.SLASH_DIAGONAL
-                )
-            )
-        } else {
-            addToBot(
-                DamageAction(
-                    m,
-                    DamageInfo(p, damage, damageTypeForTurn),
-                    AttackEffect.SLASH_DIAGONAL
-                )
-            )
-        }
+
+        marisa.addToBot(blast, action)
     }
 
     override fun makeCopy(): AbstractCard = MasterSpark()
@@ -79,6 +64,5 @@ class MasterSpark : AmplifiedAttack(
         private const val UPG_DMG = 3
         private const val AMP_DMG = 7
         private const val UPG_AMP = 2
-        private const val AMP = 1
     }
 }

--- a/src/main/kotlin/marisa/cards/OortCloud.kt
+++ b/src/main/kotlin/marisa/cards/OortCloud.kt
@@ -1,15 +1,15 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
 import com.megacrit.cardcrawl.powers.PlatedArmorPower
+import marisa.abstracts.AmplifiableCard
 import marisa.patches.AbstractCardEnum
 
-class OortCloud : CustomCard(
+class OortCloud : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -38,36 +38,22 @@ class OortCloud : CustomCard(
     }
 
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
-        if (isAmplified(AMP)) {
-            addToBot(
-                ApplyPowerAction(
-                    p,
-                    p,
-                    PlatedArmorPower(p, block),
-                    block
-                )
-            )
-        }
-        addToBot(
-            ApplyPowerAction(
-                p,
-                p,
-                PlatedArmorPower(p, magicNumber),
-                magicNumber
-            )
-        )
+        val armorValue = if (tryAmplify()) block else magicNumber
+        val action = ApplyPowerAction(p, p, PlatedArmorPower(p, armorValue), armorValue)
+
+        addToBot(action)
     }
 
     override fun makeCopy(): AbstractCard = OortCloud()
 
     override fun upgrade() {
-        if (!upgraded) {
-            upgradeName()
-            upgradeMagicNumber(UPG_ARMOR)
-            upgradeBlock(UPG_AMP)
-            //this.rawDescription = DESCRIPTION_UPG;
-            //initializeDescription();
-        }
+        if (upgraded) return
+
+        upgradeName()
+        upgradeMagicNumber(UPG_ARMOR)
+        upgradeBlock(UPG_AMP)
+        //this.rawDescription = DESCRIPTION_UPG;
+        //initializeDescription();
     }
 
     companion object {
@@ -82,6 +68,5 @@ class OortCloud : CustomCard(
         private const val UPG_ARMOR = 1
         private const val AMP_ARMOR = 2
         private const val UPG_AMP = 1
-        private const val AMP = 1
     }
 }

--- a/src/main/kotlin/marisa/cards/PulseMagic.kt
+++ b/src/main/kotlin/marisa/cards/PulseMagic.kt
@@ -1,16 +1,17 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
 import com.megacrit.cardcrawl.powers.EnergizedBluePower
+import marisa.ApplyPowerToPlayerAction
+import marisa.abstracts.AmplifiableCard
 import marisa.patches.AbstractCardEnum
 import marisa.powers.Marisa.PulseMagicPower
 
-class PulseMagic : CustomCard(
+class PulseMagic : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -26,30 +27,13 @@ class PulseMagic : CustomCard(
         magicNumber = baseMagicNumber
     }
 
-    /*
-    @Override
-    public void applyPowers() {
-      if (this.upgraded) {
-        this.retain = true;
-      }
-    }
-  */
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
-        if (isAmplified(AMP)) {
-            addToBot(
-                ApplyPowerAction(
-                    p, p, PulseMagicPower(p)
-                )
-            )
+        val action = if (tryAmplify()) {
+            ApplyPowerToPlayerAction(PulseMagicPower::class)
+        } else {
+            ApplyPowerAction(p, p, EnergizedBluePower(p, magicNumber), magicNumber)
         }
-        addToBot(
-            ApplyPowerAction(
-                p,
-                p,
-                EnergizedBluePower(p, magicNumber),
-                magicNumber
-            )
-        )
+        addToBot(action)
     }
 
     override fun makeCopy(): AbstractCard = PulseMagic()
@@ -73,6 +57,5 @@ class PulseMagic : CustomCard(
         private const val COST = 0
         private const val ENE = 1
         private const val UPG_ENE = 1
-        private const val AMP = 1
     }
 }

--- a/src/main/kotlin/marisa/cards/RefractionSpark.kt
+++ b/src/main/kotlin/marisa/cards/RefractionSpark.kt
@@ -31,21 +31,10 @@ class RefractionSpark : AmplifiedAttack(
     }
 
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
-        if (isAmplified(AMP)) {
-            addToBot(
-                RefractionSparkAction(
-                    m,
-                    DamageInfo(p, block, damageTypeForTurn)
-                )
-            )
-        } else {
-            addToBot(
-                RefractionSparkAction(
-                    m,
-                    DamageInfo(p, damage, damageTypeForTurn)
-                )
-            )
-        }
+        val damageNumber = if (tryAmplify()) block else damage
+        val action = RefractionSparkAction(m, DamageInfo(p, damageNumber, damageTypeForTurn))
+
+        addToBot(action)
     }
 
     override fun makeCopy(): AbstractCard = RefractionSpark()
@@ -71,6 +60,5 @@ class RefractionSpark : AmplifiedAttack(
         private const val UPG_DMG = 1
         private const val AMP_DMG = 3
         private const val UPG_AMP = 1
-        private const val AMP = 1
     }
 }

--- a/src/main/kotlin/marisa/cards/Robbery.kt
+++ b/src/main/kotlin/marisa/cards/Robbery.kt
@@ -1,15 +1,15 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.cards.DamageInfo
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
 import com.megacrit.cardcrawl.monsters.AbstractMonster
+import marisa.abstracts.AmplifiableCard
 import marisa.action.RobberyDamageAction
 import marisa.patches.AbstractCardEnum
 
-class Robbery : CustomCard(
+class Robbery : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -27,22 +27,18 @@ class Robbery : CustomCard(
     }
 
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
-        addToBot(
-            RobberyDamageAction(
-                m,
-                DamageInfo(p, damage, damageTypeForTurn),
-                isAmplified(AMP)
-            )
-        )
+        val action = RobberyDamageAction(m, DamageInfo(p, damage, damageTypeForTurn), tryAmplify())
+
+        addToBot(action)
     }
 
     override fun makeCopy(): AbstractCard = Robbery()
 
     override fun upgrade() {
-        if (!upgraded) {
-            upgradeName()
-            upgradeDamage(UPGRADE_PLUS_DMG)
-        }
+        if (upgraded) return
+
+        upgradeName()
+        upgradeDamage(UPGRADE_PLUS_DMG)
     }
 
     companion object {
@@ -54,6 +50,5 @@ class Robbery : CustomCard(
         private const val COST = 1
         private const val ATTACK_DMG = 7
         private const val UPGRADE_PLUS_DMG = 3
-        private const val AMP = 1
     }
 }

--- a/src/main/kotlin/marisa/cards/ShootTheMoon.kt
+++ b/src/main/kotlin/marisa/cards/ShootTheMoon.kt
@@ -34,7 +34,7 @@ class ShootTheMoon : AmplifiedAttack(
 
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
         m ?: return
-        val isAmplified = isAmplified(AMP)
+        val isAmplified = tryAmplify()
 
         val buffs = m.powers
             .filter { it.type == AbstractPower.PowerType.BUFF }
@@ -78,6 +78,5 @@ class ShootTheMoon : AmplifiedAttack(
         private const val UPG_DMG = 3
         private const val AMP_DMG = 5
         private const val UPG_AMP = 2
-        private const val AMP = 1
     }
 }

--- a/src/main/kotlin/marisa/cards/SporeBomb.kt
+++ b/src/main/kotlin/marisa/cards/SporeBomb.kt
@@ -1,16 +1,16 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
 import com.megacrit.cardcrawl.core.CardCrawlGame
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import com.megacrit.cardcrawl.monsters.AbstractMonster
 import com.megacrit.cardcrawl.powers.VulnerablePower
+import marisa.abstracts.AmplifiableCard
+import marisa.monsters
 import marisa.patches.AbstractCardEnum
 
-class SporeBomb : CustomCard(
+class SporeBomb : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -26,30 +26,17 @@ class SporeBomb : CustomCard(
         magicNumber = baseMagicNumber
     }
 
+    private fun vulnerableAction(p: AbstractPlayer, m: AbstractMonster) =
+        ApplyPowerAction(m, p, VulnerablePower(m, magicNumber, false), magicNumber)
+
     override fun use(p: AbstractPlayer, m: AbstractMonster?) {
-        if (isAmplified(AMP)) {
-            for (mo in AbstractDungeon.getCurrRoom().monsters.monsters) {
-                addToBot(
-                    ApplyPowerAction(
-                        mo,
-                        p,
-                        VulnerablePower(mo, magicNumber, false),
-                        magicNumber,
-                        true
-                    )
-                )
-            }
-        } else {
-            addToBot(
-                ApplyPowerAction(
-                    m,
-                    p,
-                    VulnerablePower(m, magicNumber, false),
-                    magicNumber,
-                    true
-                )
-            )
+        val monsters = if (tryAmplify()) monsters else {
+            m ?: return
+            listOf(m)
         }
+        val actions = monsters.map { vulnerableAction(p, it) }
+
+        marisa.addToBot(actions)
     }
 
     override fun makeCopy(): AbstractCard = SporeBomb()
@@ -68,7 +55,6 @@ class SporeBomb : CustomCard(
         val NAME = cardStrings.NAME
         val DESCRIPTION = cardStrings.DESCRIPTION
         private const val COST = 0
-        private const val AMP = 1
         private const val STC = 2
         private const val UPG_STC = 1
     }

--- a/src/main/kotlin/marisa/cards/Utils.kt
+++ b/src/main/kotlin/marisa/cards/Utils.kt
@@ -3,7 +3,6 @@ package marisa.cards
 import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.MultiCardPreview
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
-import marisa.MarisaContinued
 
 /**
  * @return copy of card that has same upgrades as this card
@@ -12,8 +11,6 @@ fun AbstractCard.followUpgrade(card: AbstractCard) =
     if (upgraded) card.upgraded() else card.makeCopy()!!
 
 fun AbstractCard.upgraded() = apply { upgrade() }
-
-fun AbstractCard.isAmplified(cost: Int = 1) = MarisaContinued.isAmplified(this, cost)
 
 fun AbstractCard.multiplePreviews(cards: List<AbstractCard>) {
     MultiCardPreview.clear(this)

--- a/src/main/kotlin/marisa/cards/WitchOfGreed.kt
+++ b/src/main/kotlin/marisa/cards/WitchOfGreed.kt
@@ -1,6 +1,5 @@
 package marisa.cards
 
-import basemod.abstracts.CustomCard
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.characters.AbstractPlayer
@@ -9,11 +8,12 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon
 import com.megacrit.cardcrawl.monsters.AbstractMonster
 import com.megacrit.cardcrawl.rooms.AbstractRoom.RoomPhase
 import marisa.MarisaContinued
+import marisa.abstracts.AmplifiableCard
 import marisa.patches.AbstractCardEnum
 import marisa.powers.Marisa.WitchOfGreedGold
 import marisa.powers.Marisa.WitchOfGreedPotion
 
-class WitchOfGreed : CustomCard(
+class WitchOfGreed : AmplifiableCard(
     ID,
     NAME,
     IMG_PATH,
@@ -30,64 +30,31 @@ class WitchOfGreed : CustomCard(
         tags.add(CardTags.HEALING)
     }
 
-    /*
-    public void use(AbstractPlayer p, AbstractMonster m) {
-
-      if (ThMod.Amplified(this, AMP)) {
-        addToBot(
-            new ApplyPowerAction(
-                p,
-                p,
-                new WitchOfGreedPotion(p, 1), 1)
-        );
-      }
-
-      ThMod.logger.info("WitchOfGreed : Applying power : gold ;");
-
-      addToBot(
-          new ApplyPowerAction(
-              p,
-              p,
-              new WitchOfGreedGold(p, this.magicNumber),
-              this.magicNumber
-          )
-      );
-    }
-  */
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
         if (AbstractDungeon.getCurrRoom().phase == RoomPhase.COMBAT) {
             AbstractDungeon.getCurrRoom().addGoldToRewards(magicNumber)
             addToBot(
-                ApplyPowerAction(
-                    p,
-                    p,
-                    WitchOfGreedGold(p, magicNumber),
-                    magicNumber
-                )
+                ApplyPowerAction(p, p, WitchOfGreedGold(p, magicNumber), magicNumber)
             )
-            if (isAmplified(AMP)) {
-                val po = AbstractDungeon.returnRandomPotion()
-                AbstractDungeon.getCurrRoom().addPotionToRewards(po)
-                addToBot(
-                    ApplyPowerAction(
-                        p,
-                        p,
-                        WitchOfGreedPotion(p, 1),
-                        1
-                    )
-                )
-                MarisaContinued.logger.info("WitchOfGreed : use : Amplified : adding :" + po.ID)
-            }
+
+            if (!tryAmplify()) return
+
+            val po = AbstractDungeon.returnRandomPotion()
+            AbstractDungeon.getCurrRoom().addPotionToRewards(po)
+            addToBot(
+                ApplyPowerAction(p, p, WitchOfGreedPotion(p, 1), 1)
+            )
+            MarisaContinued.logger.info("WitchOfGreed : use : Amplified : adding :" + po.ID)
         }
     }
 
     override fun makeCopy(): AbstractCard = WitchOfGreed()
 
     override fun upgrade() {
-        if (!upgraded) {
-            upgradeName()
-            upgradeMagicNumber(UPG_STC)
-        }
+        if (upgraded) return
+
+        upgradeName()
+        upgradeMagicNumber(UPG_STC)
     }
 
     companion object {
@@ -99,6 +66,5 @@ class WitchOfGreed : CustomCard(
         private const val COST = 1
         private const val STC = 15
         private const val UPG_STC = 10
-        private const val AMP = 1
     }
 }


### PR DESCRIPTION
## Summary

- fixes #151
- fixes #138

## Changelog

#### feat: utility getter for monsters (c0748e4)

#### feat: `AmplifiableCard` (13b298f)

#### refactor: make `AmplifiedAttack` inherit from `AmplifiableCard` (683c654)

#### refactor: remove `isAmplified` from mod class (f2eaa58)

#### refactor: migrate to `AmplifiableCard` (5721e49)