### PR TITLE
fix: amplify related bugs

### DIFF
--- a/src/main/kotlin/marisa/abstracts/AmplifiableCard.kt
+++ b/src/main/kotlin/marisa/abstracts/AmplifiableCard.kt
@@ -6,6 +6,7 @@ import com.evacipated.cardcrawl.modthespire.lib.SpireOverride
 import com.evacipated.cardcrawl.modthespire.lib.SpireSuper
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel
 import marisa.ApplyPowerToPlayerAction
+import marisa.MarisaContinued.Companion.logger
 import marisa.addToTop
 import marisa.p
 import marisa.powers.Marisa.*
@@ -37,6 +38,7 @@ abstract class AmplifiableCard(
             freeToPlayOnce -> true
             else -> false
         }
+
     private val canAmplify: Boolean
         get() = when {
             isAmplifyDisabled() -> false
@@ -74,11 +76,12 @@ abstract class AmplifiableCard(
     }
 
     fun tryAmplify(): Boolean {
-        costForTurn += additionalCostToPay
-
-        if (canAmplify) {
+        val isAmplified: Boolean = canAmplify
+        if (isAmplified) {
             applyAmplify()
         }
-        return canAmplify
+        costForTurn += additionalCostToPay
+        logger.info("$name: { isAmplified: $isAmplified, totalCost: $costForTurn }")
+        return isAmplified
     }
 }

--- a/src/main/kotlin/marisa/cards/MasterSpark.kt
+++ b/src/main/kotlin/marisa/cards/MasterSpark.kt
@@ -44,13 +44,13 @@ class MasterSpark : AmplifiedAttack(
     override fun makeCopy(): AbstractCard = MasterSpark()
 
     override fun upgrade() {
-        if (!upgraded) {
-            upgradeName()
-            upgradeDamage(UPG_DMG)
-            ampNumber += UPG_AMP
-            block = baseDamage + ampNumber
-            isBlockModified = true
-        }
+        if (upgraded) return
+
+        upgradeName()
+        upgradeDamage(UPG_DMG)
+        ampNumber += UPG_AMP
+        block = baseDamage + ampNumber
+        isBlockModified = true
     }
 
     companion object {

--- a/src/main/kotlin/marisa/cards/OortCloud.kt
+++ b/src/main/kotlin/marisa/cards/OortCloud.kt
@@ -38,7 +38,7 @@ class OortCloud : AmplifiableCard(
     }
 
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
-        val armorValue = if (tryAmplify()) block else magicNumber
+        val armorValue = magicNumber + if (tryAmplify()) block else 0
         val action = ApplyPowerAction(p, p, PlatedArmorPower(p, armorValue), armorValue)
 
         addToBot(action)

--- a/src/main/kotlin/marisa/cards/OortCloud.kt
+++ b/src/main/kotlin/marisa/cards/OortCloud.kt
@@ -52,8 +52,6 @@ class OortCloud : AmplifiableCard(
         upgradeName()
         upgradeMagicNumber(UPG_ARMOR)
         upgradeBlock(UPG_AMP)
-        //this.rawDescription = DESCRIPTION_UPG;
-        //initializeDescription();
     }
 
     companion object {

--- a/src/main/kotlin/marisa/cards/PulseMagic.kt
+++ b/src/main/kotlin/marisa/cards/PulseMagic.kt
@@ -28,12 +28,10 @@ class PulseMagic : AmplifiableCard(
     }
 
     override fun use(p: AbstractPlayer, unused: AbstractMonster?) {
-        val action = if (tryAmplify()) {
-            ApplyPowerToPlayerAction(PulseMagicPower::class)
-        } else {
-            ApplyPowerAction(p, p, EnergizedBluePower(p, magicNumber), magicNumber)
+        if (tryAmplify()) {
+            addToBot(ApplyPowerToPlayerAction(PulseMagicPower::class))
         }
-        addToBot(action)
+        addToBot(ApplyPowerAction(p, p, EnergizedBluePower(p, magicNumber), magicNumber))
     }
 
     override fun makeCopy(): AbstractCard = PulseMagic()


### PR DESCRIPTION
## Summary
- fixes #160

## Changelog

#### fix: not being able to amplify despite having enough energy (4685b07)
`canAmplify` property was calculated after `costForTurn` increased by `additionalCostToPay`.
when the card was amplifiable via paying, it increased `costForTurn`, thus making `canAmplify` false.

#### fix: `OortCloud` only giving 'bonus' armor when amplified (3f9cbf2)
error in equation made armor value either 'original' or 'bonus', not 'original' and 'bonus'.

#### fix: `PulseMagic` not giving additional energy when amplified (79ddc7b)
error in equation made 'energy' or 'pulse magic', not 'energy' and bonus 'pulse magic'

#### refactor: use early return (59c4e12)
