### PR TITLE
fix: prevent Mini-Hakkero from hovering when using cards

### DIFF
--- a/src/main/kotlin/marisa/relics/MiniHakkero.kt
+++ b/src/main/kotlin/marisa/relics/MiniHakkero.kt
@@ -2,7 +2,6 @@ package marisa.relics
 
 import basemod.abstracts.CustomRelic
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction
-import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction
 import com.megacrit.cardcrawl.actions.utility.UseCardAction
 import com.megacrit.cardcrawl.cards.AbstractCard
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon
@@ -28,7 +27,6 @@ class MiniHakkero : CustomRelic(
         flash()
         MarisaContinued.logger.info("""MiniHakkero : Applying ChargeUpPower for using card : ${card.cardID}""")
         addToTop(ApplyPowerAction(p, p, ChargeUpPower(p, 1), 1))
-        addToBot(RelicAboveCreatureAction(p, this))
     }
 
     companion object {

--- a/src/main/kotlin/marisa/relics/MiniHakkero.kt
+++ b/src/main/kotlin/marisa/relics/MiniHakkero.kt
@@ -25,6 +25,7 @@ class MiniHakkero : CustomRelic(
     override fun onUseCard(card: AbstractCard, action: UseCardAction) {
         val p = AbstractDungeon.player
 
+        flash()
         MarisaContinued.logger.info("""MiniHakkero : Applying ChargeUpPower for using card : ${card.cardID}""")
         addToTop(ApplyPowerAction(p, p, ChargeUpPower(p, 1), 1))
         addToBot(RelicAboveCreatureAction(p, this))


### PR DESCRIPTION
## Summary

- fixes #172

reverted #173 and removed `RelicAboveCreatureAction` for Mini-Hakkero.

