### PR TITLE
fix(L10n): change translation about "Wraith"

### DIFF
--- a/src/main/resources/localization/JPN/cards.json
+++ b/src/main/resources/localization/JPN/cards.json
@@ -440,8 +440,8 @@
     "DESCRIPTION": " 脱力 99 を 与える。 NL 廃棄"
   },
   "Wraith": {
-    "NAME": "悪霊",
-    "DESCRIPTION": "使用不可 NL あなたのターン終了時に 悪霊 1 を得る。"
+    "NAME": "怨霊",
+    "DESCRIPTION": "使用不可 NL あなたのターン終了時に 怨霊 1 を得る。"
   },
   "Acceleration": {
     "NAME": "アクセラレーション",


### PR DESCRIPTION
- fixes #188 

## Summary

1. change translation about "Wraith" (before: "悪霊", after:"怨霊")

Because the new translation was more appropriate considering the event to get this card, I thought.