### PR TITLE
fix: relic outline color not being applied with chimera cards

### DIFF
--- a/src/main/kotlin/marisa/MarisaContinued.kt
+++ b/src/main/kotlin/marisa/MarisaContinued.kt
@@ -87,7 +87,10 @@ class MarisaContinued :
             MiniHakkero(), BewitchedHakkero(), MagicBroom(), AmplifyWand(),
             ExperimentalFamiliar(), RampagingMagicTools(), BreadOfAWashokuLover(), SimpleLauncher(),
             HandmadeGrimoire(), ShroomBag(), SproutingBranch(), BigShroomBag()
-        ).forEach { BaseMod.addRelicToCustomPool(it, AbstractCardEnum.MARISA_COLOR) }
+        ).forEach { relic ->
+            logger.info("""Adding relic: ${relic.name}""")
+            BaseMod.addRelicToCustomPool(relic, AbstractCardEnum.MARISA_COLOR)
+        }
         BaseMod.addRelic(CatCart(), RelicType.SHARED)
     }
 
@@ -235,7 +238,7 @@ class MarisaContinued :
         private const val SKILL_CC_PORTRAIT = "marisa/img/1024/bg_skill_MRS.png"
         private const val POWER_CC_PORTRAIT = "marisa/img/1024/bg_power_MRS.png"
         private const val ENERGY_ORB_CC_PORTRAIT = "marisa/img/1024/cardOrb.png"
-        val STARLIGHT: Color = CardHelper.getColor(0, 10, 125)
+        val STARLIGHT: Color = CardHelper.getColor(20, 84, 181)
         const val CARD_ENERGY_ORB = "marisa/img/UI/energyOrb.png"
         private const val MY_CHARACTER_BUTTON = "marisa/img/charSelect/MarisaButton.png"
         private const val MARISA_PORTRAIT = "marisa/img/charSelect/marisaPortrait.jpg"

--- a/src/main/kotlin/marisa/characters/Marisa.kt
+++ b/src/main/kotlin/marisa/characters/Marisa.kt
@@ -138,7 +138,7 @@ class Marisa(name: String) :
         else -> "The Ordinary Magician"
     }
 
-    override fun getCardTrailColor(): Color = MarisaContinued.STARLIGHT
+    override fun getCardTrailColor(): Color = MarisaContinued.STARLIGHT.cpy()
 
     override fun getAscensionMaxHPLoss(): Int = ASCENSION_MAX_HP_LOSS
 
@@ -165,7 +165,7 @@ class Marisa(name: String) :
 
     override fun getVampireText(): String = Vampires.DESCRIPTIONS[1]
 
-    override fun getCardRenderColor(): Color = MarisaContinued.STARLIGHT
+    override fun getCardRenderColor(): Color = MarisaContinued.STARLIGHT.cpy()
 
     override fun updateOrb(orbCount: Int) {
         energyOrb.updateOrb(orbCount)
@@ -174,7 +174,7 @@ class Marisa(name: String) :
     override fun getOrb() =
         AtlasRegion(ImageMaster.loadImage(MarisaContinued.CARD_ENERGY_ORB), 0, 0, 24, 24)
 
-    override fun getSlashAttackColor(): Color = MarisaContinued.STARLIGHT
+    override fun getSlashAttackColor(): Color = MarisaContinued.STARLIGHT.cpy()
 
     override fun getSpireHeartSlashEffect(): Array<AttackEffect> {
         return arrayOf(


### PR DESCRIPTION
# Summary

![image](https://github.com/scarf005/Marisa/assets/54838975/87378c84-823b-47a6-979a-2fa9e589a168)

- fixes #220 

also changes relic outline color to be pretty
