### PR TITLE
fix(L10n): misleading acceleration description

### DIFF
--- a/src/main/resources/marisa/localization/ENG/cards.json
+++ b/src/main/resources/marisa/localization/ENG/cards.json
@@ -437,6 +437,6 @@
   },
   "Acceleration": {
     "NAME": "Acceleration",
-    "DESCRIPTION": "Draw top !B! cards in your draw pile. NL Amplify  [E] : Draw !M! more."
+    "DESCRIPTION": "Draw !B! cards. NL Amplify  [E] : Draw !M! more."
   }
 }


### PR DESCRIPTION

# Summary

- fixes #223 

## Description

To change card text to match change from #63 as discussed in #223 by aligning card text to match mechanics change in #63
