### PR TITLE
fix(i18n): Correct mistranslation of "One Time Off" (ZHS & ZHT)

### DIFF
--- a/src/main/resources/marisa/localization/ZHS/cards.json
+++ b/src/main/resources/marisa/localization/ZHS/cards.json
@@ -297,7 +297,7 @@
   },
   "OneTimeOff": {
     "NAME": "一回休",
-    "DESCRIPTION": "获得 !B! 点 格挡  ，这回合你将不能发动 增幅 和 蓄力 效果。 NL 下回合抽 !M! 张牌。",
+    "DESCRIPTION": "获得 !B! 点 格挡  ，这回合你将不能发动 增幅 效果。 NL 下回合抽 !M! 张牌。",
     "UPGRADE_DESCRIPTION": "获得 !B! 点 格挡  ，这回合你将不能发动 增幅 和 蓄力 效果。 NL 下回合抽 !M! 张牌。"
   },
   "DarkMatter": {

--- a/src/main/resources/marisa/localization/ZHT/cards.json
+++ b/src/main/resources/marisa/localization/ZHT/cards.json
@@ -297,7 +297,7 @@
   },
   "OneTimeOff": {
     "NAME": "一回休",
-    "DESCRIPTION": "獲得 !B! 點 格擋 ，本回合不能發動 增幅 和 蓄力 。 NL 下回合抽 !M! 張牌",
+    "DESCRIPTION": "獲得 !B! 點 格擋 ，本回合不能發動 增幅 。 NL 下回合抽 !M! 張牌",
     "UPGRADE_DESCRIPTION": "獲得 !B! 點 格擋 ，本回合不能發動 增幅 和 蓄力 。 NL 下回合抽 !M! 張牌"
   },
   "DarkMatter": {


### PR DESCRIPTION
# Summary

<!--
see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

- The translation of "One Time Off" was incorrect and did not match its actual effect in the game. This fix corrects the translation to accurately reflect its in-game effect.
