### PR TITLE
fix: make `ShootTheMoon` remove buff first before attacking

### DIFF
--- a/src/main/kotlin/marisa/cards/ShootTheMoon.kt
+++ b/src/main/kotlin/marisa/cards/ShootTheMoon.kt
@@ -49,10 +49,10 @@ class ShootTheMoon : AmplifiedAttack(
         }
 
         val harm = if (isAmplified) block else damage
+        toRemove.forEach { addToBot(it) }
         addToBot(
             DamageAction(m, DamageInfo(p, harm, damageTypeForTurn), AttackEffect.SLASH_DIAGONAL)
         )
-        toRemove.forEach { addToBot(it) }
     }
 
     override fun makeCopy(): AbstractCard = ShootTheMoon()


### PR DESCRIPTION
# Summary

https://github.com/scarf005/Marisa/assets/54838975/26aa50c2-f7c1-43ee-a28a-b452cf7176f3



- fixes #239
